### PR TITLE
Additional Hotkey Support

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,16 +14,25 @@
    },
    "commands": {
       "next": {
-         "description": "next track",
+         "description": "Next track",
          "suggested_key": "Alt+Shift+Period"
       },
       "play-pause": {
-         "description": "play/pause",
+         "description": "Play/pause",
          "suggested_key": "Alt+Shift+P"
       },
       "previous": {
-         "description": "previous track",
+         "description": "Previous track",
          "suggested_key": "Alt+Shift+Comma"
+      },
+      "shuffle": {
+         "description": "Shuffle"
+      },
+      "repeat": {
+         "description": "Repeat"
+      },
+      "track-add": {
+         "description": "Save track"
       }
    },
    "permissions": [ "https://play.spotify.com/*"  ]


### PR DESCRIPTION
Added some additional hotkeys for `Shuffle`, `Repeat` and `Save Track`. Also modified the case of the existing descriptions for the sake of consistency, to match the rest of the Chrome settings.

I haven't added suggested keys to these additional 3 actions, as Chrome seems to have a hard-coded constant limiting the amount of Commands containing Suggested Keys to 4. However, this limitation doesn't extend to Commands without Suggested Keys.
