### PR TITLE
Update to work with latest version of spotify

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,12 +1,12 @@
 function onCommand(command) {
-  chrome.tabs.query({url: 'https://play.spotify.com/*'}, function(tabs) {
+  chrome.tabs.query({url: ['https://play.spotify.com/*','https://player.spotify.com/*']}, function(tabs) {
 
     // Open a spotify tab if one does not exist yet.
     if (tabs.length === 0) {
       chrome.tabs.create({url: 'https://play.spotify.com'});
     }
 
-    var code = "document.getElementById('app-player').contentDocument.getElementById('" + command + "').click()";
+    var code = "document.getElementById('main').contentDocument.getElementById('" + command + "').click()";
     // Apply command on all spotify tabs.
     for (var tab of tabs) {
       chrome.tabs.executeScript(tab.id, {code: code});


### PR DESCRIPTION
Adds support for https://player.spotify.com
and used the main id instead of app-player because app-player seems to not exist anymore.
