### PR TITLE
Updated to work with Spotify's new javascript web player

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,12 +1,19 @@
 function onCommand(command) {
-  chrome.tabs.query({url: 'https://play.spotify.com/*'}, function(tabs) {
+  chrome.tabs.query({url: 'https://open.spotify.com/*'}, function(tabs) {
 
     // Open a spotify tab if one does not exist yet.
     if (tabs.length === 0) {
-      chrome.tabs.create({url: 'https://play.spotify.com'});
+      chrome.tabs.create({url: 'https://open.spotify.com'});
     }
 
-    var code = "document.getElementById('app-player').contentDocument.getElementById('" + command + "').click()";
+    if (command == 'Play') {
+      var selector = "button[title=Play], button[title=Pause]"
+    } else {
+      var selector = "button[title$=" + command + "]"
+    }
+
+    var code = "document.querySelector('" + selector + "').click()";
+
     // Apply command on all spotify tabs.
     for (var tab of tabs) {
       chrome.tabs.executeScript(tab.id, {code: code});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
    "name": "Spotify Web Player Hotkeys",
    "description": "Add keyboard shortcuts to pause, play next and previous tracks in Spotify",
-   "version": "0.3",
+   "version": "0.4",
    "manifest_version": 2,
    "icons": {
       "128": "icon.png"
@@ -13,15 +13,15 @@
       "scripts": [ "background.js" ]
    },
    "commands": {
-      "next": {
+      "Next": {
          "description": "Next track",
          "suggested_key": "Alt+Shift+Period"
       },
-      "play-pause": {
+      "Play": {
          "description": "Play/pause",
          "suggested_key": "Alt+Shift+P"
       },
-      "previous": {
+      "Previous": {
          "description": "Previous track",
          "suggested_key": "Alt+Shift+Comma"
       },
@@ -30,10 +30,7 @@
       },
       "repeat": {
          "description": "Repeat"
-      },
-      "track-add": {
-         "description": "Save track"
       }
    },
-   "permissions": [ "https://play.spotify.com/*"  ]
+   "permissions": [ "https://open.spotify.com/*"  ]
 }


### PR DESCRIPTION
This allows the extension to work with Spotify's new open.spotify.com javascript player. I assume this will be the default player for everyone in the near future if it is not already.

This PR does break backward compatibility with the old flash-based web player.