### PR TITLE
Fix save track action

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -18,7 +18,7 @@ function onCommand(command) {
           case 'previous': code = 'document.querySelector(".spoticon-skip-back-16").click()'; break;
           case 'shuffle': code = 'document.querySelector(".spoticon-shuffle-16").click()'; break;
           case 'repeat': code = 'document.querySelector(".spoticon-repeat-16").click()'; break;
-          case 'track-add': code = '(document.querySelector(".spoticon-heart-16") || document.querySelector(".spoticon-heart-active-16")).click()'; break;
+          case 'track-add': code = '(document.querySelector(".spoticon-add-16") || document.querySelector(".spoticon-added-16")).click()'; break;
           case 'play-pause': code = '(document.querySelector(".spoticon-play-16") || document.querySelector(".spoticon-pause-16")).click()'; break;
         }
       }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
    "name": "Spotify Web Player Hotkeys",
    "description": "Add keyboard shortcuts to pause, play next and previous tracks in Spotify",
-   "version": "0.5.4",
+   "version": "0.5.5",
    "manifest_version": 2,
    "icons": {
       "128": "icon.png"


### PR DESCRIPTION
Looks like open.spotify is using 'spoticon-add-16' and 'spoticon-added-16' icons once again for the 'save track' action.